### PR TITLE
Add mobile GPS logging Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Cullinan30a Web Tools Collection 20/8/2025| 工具集合
 
-## Latest Update (v6.9) 20/08/2025
+## Latest Update (v6.13) 16/10/2025
 
-- **Full authentication system**: All pages now require login via `auth.html` (multi-password, 24h session, logout)
-- **FacePack.ID dashboard**: Real-time API, activity log, ChatGPT integration
-- **ABC Drive Viewer**: Updated Apps Script endpoint, new folder ID, improved file listing and debug tools
-- **Status bar**: v6.9 | Updated: 2025-08-16 | Auth Protected + FacePack Dashboard
-- **Deployment**: Vercel auto-deploy, GitHub integration
+- **Mobile GPS Logger Apps Script**: New phone-friendly web app captures device geolocation and appends entries to the `Lfile` inside the chatgpt Drive folder (with API mode for direct calls)
+- **Secure logging workflow**: Script-level locking prevents race conditions, while entries are timestamped in GMT+8 with device metadata
+- **Index status refresh**: Version banner now highlights the GPS logger release with up-to-date timestamp information
 
 🌐 **Live Site**: [https://v0-cullinan30a.vercel.app/](https://v0-cullinan30a.vercel.app/)
 
@@ -49,6 +47,12 @@
 ### 7. 🤖 AI Prompt Generator
 
 - **ai_prompt_generator.html**: Generate prompts for various AI applications, customizable templates
+
+### 8. 📍 Mobile GPS Logger (Apps Script)
+
+- **gps_logger_appscript.gs / gpsLogger.html**: Deployable Google Apps Script web app that requests mobile GPS access
+- **Automatic Drive logging**: Stores timestamped coordinates inside `Lfile` within the chatgpt folder (with web + API capture modes)
+- **Device metadata**: Captures accuracy + user agent for auditing and troubleshooting
 
 ## 🛠️ Getting Started | 開始使用
 

--- a/gpsLogger.html
+++ b/gpsLogger.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body {
+        font-family: 'Segoe UI', Roboto, sans-serif;
+        margin: 0;
+        padding: 24px;
+        background: #f4f6fb;
+        color: #1f2933;
+      }
+
+      h1 {
+        font-size: 20px;
+        margin-bottom: 12px;
+      }
+
+      .card {
+        background: white;
+        border-radius: 12px;
+        padding: 20px;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+      }
+
+      .status {
+        margin-top: 16px;
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: #eef2ff;
+        color: #3730a3;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .status.error {
+        background: #fee2e2;
+        color: #b91c1c;
+      }
+
+      .status.success {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .meta {
+        margin-top: 12px;
+        color: #64748b;
+        font-size: 12px;
+      }
+
+      button {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 10px 16px;
+        border-radius: 999px;
+        border: none;
+        background: #2563eb;
+        color: white;
+        font-size: 14px;
+        cursor: pointer;
+        box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>📍 Mobile GPS Logger</h1>
+      <p>This web app requests your device location and writes it into the <strong>Lfile</strong> stored inside the <em>chatgpt</em> Google Drive folder.</p>
+      <p class="meta">Generated at: <?= generatedAt ?> (GMT+8)</p>
+      <button id="captureBtn">Capture Current Location</button>
+      <div id="status" class="status">Waiting for permission…</div>
+    </div>
+
+    <script>
+      const statusEl = document.getElementById('status');
+      const buttonEl = document.getElementById('captureBtn');
+
+      function setStatus(message, type = '') {
+        statusEl.textContent = message;
+        statusEl.className = 'status' + (type ? ' ' + type : '');
+      }
+
+      function captureLocation() {
+        if (!navigator.geolocation) {
+          setStatus('Geolocation is not supported by this device/browser.', 'error');
+          buttonEl.disabled = true;
+          return;
+        }
+
+        setStatus('Requesting GPS position…');
+        buttonEl.disabled = true;
+
+        navigator.geolocation.getCurrentPosition(onSuccess, onError, {
+          enableHighAccuracy: true,
+          timeout: 20000,
+          maximumAge: 0
+        });
+      }
+
+      function onSuccess(position) {
+        const coords = position.coords;
+        const payload = {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          accuracy: coords.accuracy,
+          deviceInfo: navigator.userAgent,
+          source: 'mobile-webapp'
+        };
+
+        setStatus('Location captured. Saving to Google Drive…');
+
+        google.script.run
+          .withSuccessHandler(result => {
+            if (result && result.success) {
+              setStatus('✅ Location logged to Lfile.\n' + result.entry, 'success');
+              buttonEl.disabled = false;
+            } else {
+              setStatus('Failed to log location. Please try again later.', 'error');
+              buttonEl.disabled = false;
+            }
+          })
+          .withFailureHandler(err => {
+            console.error(err);
+            setStatus('Error logging location: ' + err.message, 'error');
+            buttonEl.disabled = false;
+          })
+          .logLocationFromClient(payload);
+      }
+
+      function onError(error) {
+        console.error(error);
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            setStatus('Permission denied. Enable location access and try again.', 'error');
+            break;
+          case error.POSITION_UNAVAILABLE:
+            setStatus('Location information is unavailable. Move to an open area and retry.', 'error');
+            break;
+          case error.TIMEOUT:
+            setStatus('Location request timed out. Please try again.', 'error');
+            break;
+          default:
+            setStatus('An unknown error occurred while retrieving location.', 'error');
+        }
+        buttonEl.disabled = false;
+      }
+
+      buttonEl.addEventListener('click', () => {
+        buttonEl.disabled = true;
+        captureLocation();
+      });
+
+      // Auto-trigger on load for convenience
+      captureLocation();
+    </script>
+  </body>
+</html>

--- a/gps_logger_appscript.gs
+++ b/gps_logger_appscript.gs
@@ -1,0 +1,112 @@
+/**
+ * Google Apps Script: Mobile GPS Logger
+ * Deploy as a Web App. When opened on a phone, the page requests GPS permission
+ * and logs the coordinates into the "Lfile" located in the chatgpt Google Drive folder.
+ *
+ * Folder ID: 1dVrvGaIwFAaM4qdWxk_DLeKnYbIJjxxd
+ */
+
+const CHATGPT_FOLDER_ID = '1dVrvGaIwFAaM4qdWxk_DLeKnYbIJjxxd';
+const LOG_FILE_NAME = 'Lfile';
+const HKT_TIMEZONE = 'Asia/Hong_Kong'; // GMT+8
+
+function doGet(e) {
+  if (e && e.parameter && (e.parameter.mode || e.parameter.action)) {
+    const mode = (e.parameter.mode || e.parameter.action || '').toLowerCase();
+    if (mode === 'log' || mode === 'capture') {
+      return handleApiLog(e.parameter);
+    }
+  }
+
+  const template = HtmlService.createTemplateFromFile('gpsLogger');
+  template.generatedAt = Utilities.formatDate(new Date(), HKT_TIMEZONE, 'yyyy-MM-dd HH:mm:ss');
+
+  return template
+    .evaluate()
+    .setTitle('GPS Logger | chatgpt Folder')
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function handleApiLog(params) {
+  try {
+    const latitude = parseFloat(params.lat || params.latitude);
+    const longitude = parseFloat(params.lng || params.lon || params.longitude);
+    const accuracy = params.acc || params.accuracy ? Number(params.acc || params.accuracy) : null;
+    const deviceInfo = params.device || params.deviceInfo || '';
+
+    if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+      throw new Error('Missing latitude/longitude');
+    }
+
+    const result = writeLocationEntry({
+      latitude,
+      longitude,
+      accuracy,
+      deviceInfo,
+      source: 'api-request'
+    });
+
+    return createJsonResponse({ success: true, entry: result.entry, message: 'Location stored in Lfile.' });
+  } catch (error) {
+    return createJsonResponse({ success: false, message: error.message });
+  }
+}
+
+function logLocationFromClient(payload) {
+  if (!payload) {
+    throw new Error('No payload supplied');
+  }
+
+  const result = writeLocationEntry({
+    latitude: Number(payload.latitude),
+    longitude: Number(payload.longitude),
+    accuracy: payload.accuracy !== undefined ? Number(payload.accuracy) : null,
+    deviceInfo: payload.deviceInfo || '',
+    source: payload.source || 'mobile-webapp'
+  });
+
+  return { success: true, entry: result.entry };
+}
+
+function writeLocationEntry(data) {
+  if (Number.isNaN(data.latitude) || Number.isNaN(data.longitude)) {
+    throw new Error('Invalid GPS coordinates');
+  }
+
+  const lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+  try {
+    const folder = DriveApp.getFolderById(CHATGPT_FOLDER_ID);
+    let file;
+    const existing = folder.getFilesByName(LOG_FILE_NAME);
+    if (existing.hasNext()) {
+      file = existing.next();
+    } else {
+      file = folder.createFile(LOG_FILE_NAME, 'timestamp,latitude,longitude,accuracy,device,source\n');
+    }
+
+    const timestamp = Utilities.formatDate(new Date(), HKT_TIMEZONE, "yyyy-MM-dd HH:mm:ss 'GMT+8'");
+    const cleanAccuracy = data.accuracy !== null && !Number.isNaN(data.accuracy) ? data.accuracy : '';
+    const sanitizedDevice = (data.deviceInfo || '').replace(/[\r\n]+/g, ' ').trim();
+    const source = (data.source || '').replace(/[\r\n]+/g, ' ').trim();
+
+    const entry = `${timestamp},${data.latitude},${data.longitude},${cleanAccuracy},${sanitizedDevice},${source}\n`;
+    const content = file.getBlob().getDataAsString() + entry;
+    file.setContent(content);
+
+    return { entry, fileId: file.getId() };
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function createJsonResponse(obj) {
+  return ContentService
+    .createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}

--- a/index.html
+++ b/index.html
@@ -128,6 +128,20 @@
       color: #856404;
       margin-left: 8px;
     }
+
+    .release-note {
+      border: 1px solid #2563eb;
+      background-color: #eef2ff;
+      padding: 12px 16px;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    .release-note strong {
+      color: #1d4ed8;
+    }
   </style>
 </head>
 
@@ -168,8 +182,13 @@
     }
   </script>
 
-  <!-- version: v6.12 | Updated: 2025-08-22 (2025-08-16) -->
-  <div class="status-bar">v6.12 | Updated: 2025-08-22 | Updated: 2025-08-16 | Auth Protected + FacePack Dashboard | 🔐 Secure Access Enabled
+  <!-- version: v6.13 | Updated: 2025-10-16 22:29 (GMT+8) -->
+  <div class="status-bar">v6.13 | Updated: 2025-10-16 22:29 (GMT+8) | Auth Protected + FacePack Dashboard | 📍 Mobile GPS Logger Ready | 🔐 Secure Access Enabled
+  </div>
+
+  <div class="release-note">
+    <strong>v6.13 – 2025-10-16 22:29 (GMT+8):</strong> Added a Google Apps Script GPS logger that lets mobile devices capture their
+    current coordinates and append them to the chatgpt folder's Lfile via secure Drive logging.
   </div>
 
   <button class="logout-btn" onclick="logout()">🚪 Logout</button>


### PR DESCRIPTION
## Summary
- add a deployable Google Apps Script (code + HTML) that captures mobile GPS coordinates and appends them to the chatgpt folder Lfile
- refresh the project README with the v6.13 release notes and feature list entry for the GPS logger
- bump the index status banner to v6.13 with a GMT+8 timestamped release note

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f100f35374832d92751885b1ff18e2