### PR TITLE
Add GPS logger entry to index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Cullinan30a Web Tools Collection 20/8/2025| 工具集合
 
-## Latest Update (v6.15) 17/10/2025
+## Latest Update (v6.16) 17/10/2025
 
-- **Index shortcut for GPS logger**: Added the Mobile GPS Logger page to the main index so field teams can launch the Apps Script capture UI directly
-- **Deployment fix carryover**: Retains the hardened POST endpoint, validation, and logging updates introduced in v6.14 for stable Drive writes
-- **Mobile-first continuity**: Keeps the capture preview tweaks to reassure users after every logged coordinate
+- **GPS quick-launch card**: Added a dedicated Mobile GPS Logger card to the bottom of `index.html` with inline instructions and a one-tap launch button
+- **Dashboard consistency**: Keeps the index entry from v6.15 so the logger appears in both the list view and the new quick-launch area
+- **Documentation refresh**: Updated release notes to highlight the inline access point alongside the hardened Apps Script backend from v6.14
 
 🌐 **Live Site**: [https://v0-cullinan30a.vercel.app/](https://v0-cullinan30a.vercel.app/)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Cullinan30a Web Tools Collection 20/8/2025| 工具集合
 
-## Latest Update (v6.9) 20/08/2025
+## Latest Update (v6.15) 17/10/2025
 
-- **Full authentication system**: All pages now require login via `auth.html` (multi-password, 24h session, logout)
-- **FacePack.ID dashboard**: Real-time API, activity log, ChatGPT integration
-- **ABC Drive Viewer**: Updated Apps Script endpoint, new folder ID, improved file listing and debug tools
-- **Status bar**: v6.9 | Updated: 2025-08-16 | Auth Protected + FacePack Dashboard
-- **Deployment**: Vercel auto-deploy, GitHub integration
+- **Index shortcut for GPS logger**: Added the Mobile GPS Logger page to the main index so field teams can launch the Apps Script capture UI directly
+- **Deployment fix carryover**: Retains the hardened POST endpoint, validation, and logging updates introduced in v6.14 for stable Drive writes
+- **Mobile-first continuity**: Keeps the capture preview tweaks to reassure users after every logged coordinate
 
 🌐 **Live Site**: [https://v0-cullinan30a.vercel.app/](https://v0-cullinan30a.vercel.app/)
 
@@ -49,6 +47,12 @@
 ### 7. 🤖 AI Prompt Generator
 
 - **ai_prompt_generator.html**: Generate prompts for various AI applications, customizable templates
+
+### 8. 📍 Mobile GPS Logger (Apps Script)
+
+- **gps_logger_appscript.gs / gpsLogger.html**: Deployable Google Apps Script web app that requests mobile GPS access
+- **Automatic Drive logging**: Stores timestamped coordinates inside `Lfile` within the chatgpt folder (with web + API capture modes)
+- **Device metadata**: Captures accuracy + user agent for auditing and troubleshooting
 
 ## 🛠️ Getting Started | 開始使用
 

--- a/gpsLogger.html
+++ b/gpsLogger.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body {
+        font-family: 'Segoe UI', Roboto, sans-serif;
+        margin: 0;
+        padding: 24px;
+        background: #f4f6fb;
+        color: #1f2933;
+      }
+
+      h1 {
+        font-size: 20px;
+        margin-bottom: 12px;
+      }
+
+      .card {
+        background: white;
+        border-radius: 12px;
+        padding: 20px;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+      }
+
+      .status {
+        margin-top: 16px;
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: #eef2ff;
+        color: #3730a3;
+        font-size: 14px;
+        line-height: 1.5;
+        white-space: pre-line;
+      }
+
+      .status.error {
+        background: #fee2e2;
+        color: #b91c1c;
+      }
+
+      .status.success {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .meta {
+        margin-top: 12px;
+        color: #64748b;
+        font-size: 12px;
+      }
+
+      button {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 10px 16px;
+        border-radius: 999px;
+        border: none;
+        background: #2563eb;
+        color: white;
+        font-size: 14px;
+        cursor: pointer;
+        box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+
+      .entry-preview {
+        margin-top: 16px;
+        font-size: 12px;
+        color: #475569;
+        padding: 10px 12px;
+        border-radius: 6px;
+        background: #f8fafc;
+        border: 1px solid #cbd5f5;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>📍 Mobile GPS Logger</h1>
+      <p>
+        This web app requests your device location and writes it into the <strong>Lfile</strong> stored inside the
+        <em>chatgpt</em> Google Drive folder.
+      </p>
+      <p class="meta">Generated at: <?= generatedAt ?> (GMT+8)</p>
+      <button id="captureBtn">Capture Current Location</button>
+      <div id="status" class="status">Waiting for permission…</div>
+      <div id="entryPreview" class="entry-preview" hidden></div>
+    </div>
+
+    <script>
+      const statusEl = document.getElementById('status');
+      const buttonEl = document.getElementById('captureBtn');
+      const entryPreviewEl = document.getElementById('entryPreview');
+
+      function setStatus(message, type = '') {
+        statusEl.textContent = message;
+        statusEl.className = 'status' + (type ? ' ' + type : '');
+      }
+
+      function showEntryPreview(entry) {
+        if (!entry) {
+          entryPreviewEl.hidden = true;
+          entryPreviewEl.textContent = '';
+          return;
+        }
+        entryPreviewEl.hidden = false;
+        entryPreviewEl.textContent = 'Last log entry:\n' + entry;
+      }
+
+      function captureLocation() {
+        if (!navigator.geolocation) {
+          setStatus('Geolocation is not supported by this device/browser.', 'error');
+          buttonEl.disabled = true;
+          return;
+        }
+
+        setStatus('Requesting GPS position…');
+        buttonEl.disabled = true;
+
+        navigator.geolocation.getCurrentPosition(onSuccess, onError, {
+          enableHighAccuracy: true,
+          timeout: 20000,
+          maximumAge: 0
+        });
+      }
+
+      function onSuccess(position) {
+        const coords = position.coords;
+        const payload = {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          accuracy: coords.accuracy,
+          deviceInfo: navigator.userAgent,
+          source: 'mobile-webapp'
+        };
+
+        setStatus('Location captured. Saving to Google Drive…');
+
+        google.script.run
+          .withSuccessHandler(result => {
+            if (result && result.success) {
+              setStatus('✅ Location logged to Lfile.', 'success');
+              showEntryPreview(result.entry);
+              buttonEl.disabled = false;
+            } else {
+              setStatus('Failed to log location. Please try again later.', 'error');
+              buttonEl.disabled = false;
+            }
+          })
+          .withFailureHandler(err => {
+            console.error(err);
+            setStatus('Error logging location: ' + err.message, 'error');
+            buttonEl.disabled = false;
+          })
+          .logLocationFromClient(payload);
+      }
+
+      function onError(error) {
+        console.error(error);
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            setStatus('Permission denied. Enable location access and try again.', 'error');
+            break;
+          case error.POSITION_UNAVAILABLE:
+            setStatus('Location information is unavailable. Move to an open area and retry.', 'error');
+            break;
+          case error.TIMEOUT:
+            setStatus('Location request timed out. Please try again.', 'error');
+            break;
+          default:
+            setStatus('An unknown error occurred while retrieving location.', 'error');
+        }
+        buttonEl.disabled = false;
+      }
+
+      buttonEl.addEventListener('click', () => {
+        buttonEl.disabled = true;
+        captureLocation();
+      });
+
+      // Auto-trigger on load for convenience
+      captureLocation();
+    </script>
+  </body>
+</html>

--- a/gps_logger_appscript.gs
+++ b/gps_logger_appscript.gs
@@ -1,0 +1,170 @@
+/**
+ * Google Apps Script: Mobile GPS Logger (v2)
+ * Deploy as a Web App. When opened on a phone, the page requests GPS permission
+ * and logs the coordinates into the "Lfile" located in the chatgpt Google Drive folder.
+ *
+ * Folder ID: 1dVrvGaIwFAaM4qdWxk_DLeKnYbIJjxxd
+ */
+
+const CHATGPT_FOLDER_ID = '1dVrvGaIwFAaM4qdWxk_DLeKnYbIJjxxd';
+const LOG_FILE_NAME = 'Lfile';
+const HKT_TIMEZONE = 'Asia/Hong_Kong'; // GMT+8
+const SCRIPT_PROP_FILE_ID = 'gpsLogger.logFileId';
+
+function doGet(e) {
+  if (e && e.parameter && (e.parameter.mode || e.parameter.action)) {
+    const mode = (e.parameter.mode || e.parameter.action || '').toLowerCase();
+    if (mode === 'log' || mode === 'capture') {
+      return handleApiLog(e.parameter);
+    }
+  }
+
+  const template = HtmlService.createTemplateFromFile('gpsLogger');
+  template.generatedAt = Utilities.formatDate(new Date(), HKT_TIMEZONE, 'yyyy-MM-dd HH:mm:ss');
+
+  return template
+    .evaluate()
+    .setTitle('GPS Logger | chatgpt Folder')
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function doPost(e) {
+  try {
+    if (!e || !e.postData || !e.postData.contents) {
+      throw new Error('No POST payload supplied');
+    }
+
+    const payload = JSON.parse(e.postData.contents);
+    const latitude = toNumber(payload.latitude, 'latitude');
+    const longitude = toNumber(payload.longitude, 'longitude');
+
+    const result = writeLocationEntry({
+      latitude,
+      longitude,
+      accuracy: payload.accuracy !== undefined ? toOptionalNumber(payload.accuracy) : null,
+      deviceInfo: payload.deviceInfo || payload.device || '',
+      source: payload.source || 'mobile-post'
+    });
+
+    return createJsonResponse({ success: true, entry: result.entry, fileId: result.fileId });
+  } catch (error) {
+    return createJsonResponse({ success: false, message: error.message });
+  }
+}
+
+function handleApiLog(params) {
+  try {
+    const latitude = toNumber(params.lat || params.latitude, 'latitude');
+    const longitude = toNumber(params.lng || params.lon || params.longitude, 'longitude');
+    const accuracy = params.acc || params.accuracy ? toOptionalNumber(params.acc || params.accuracy) : null;
+    const deviceInfo = params.device || params.deviceInfo || '';
+
+    const result = writeLocationEntry({
+      latitude,
+      longitude,
+      accuracy,
+      deviceInfo,
+      source: 'api-request'
+    });
+
+    return createJsonResponse({ success: true, entry: result.entry, message: 'Location stored in Lfile.' });
+  } catch (error) {
+    return createJsonResponse({ success: false, message: error.message });
+  }
+}
+
+function logLocationFromClient(payload) {
+  if (!payload) {
+    throw new Error('No payload supplied');
+  }
+
+  const latitude = toNumber(payload.latitude, 'latitude');
+  const longitude = toNumber(payload.longitude, 'longitude');
+
+  const result = writeLocationEntry({
+    latitude,
+    longitude,
+    accuracy: payload.accuracy !== undefined ? toOptionalNumber(payload.accuracy) : null,
+    deviceInfo: payload.deviceInfo || '',
+    source: payload.source || 'mobile-webapp'
+  });
+
+  return { success: true, entry: result.entry, fileId: result.fileId };
+}
+
+function writeLocationEntry(data) {
+  const lock = LockService.getScriptLock();
+  lock.waitLock(20000);
+  try {
+    const file = getOrCreateLogFile();
+
+    const timestamp = Utilities.formatDate(new Date(), HKT_TIMEZONE, "yyyy-MM-dd HH:mm:ss 'GMT+8'");
+    const cleanAccuracy = data.accuracy !== null && !Number.isNaN(data.accuracy) ? data.accuracy : '';
+    const sanitizedDevice = sanitizeText(data.deviceInfo || '');
+    const source = sanitizeText(data.source || '');
+
+    const entry = [timestamp, data.latitude, data.longitude, cleanAccuracy, sanitizedDevice, source]
+      .map(value => value !== undefined && value !== null ? value : '')
+      .join(',');
+
+    const existingContent = file.getBlob().getDataAsString();
+    file.setContent(existingContent + entry + '\n');
+
+    return { entry, fileId: file.getId() };
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function getOrCreateLogFile() {
+  const props = PropertiesService.getScriptProperties();
+  const cachedId = props.getProperty(SCRIPT_PROP_FILE_ID);
+
+  if (cachedId) {
+    try {
+      return DriveApp.getFileById(cachedId);
+    } catch (error) {
+      // If file was deleted or ID invalid, fall through to recreate lookup
+    }
+  }
+
+  const folder = DriveApp.getFolderById(CHATGPT_FOLDER_ID);
+  let file;
+  const existing = folder.getFilesByName(LOG_FILE_NAME);
+  if (existing.hasNext()) {
+    file = existing.next();
+  } else {
+    file = folder.createFile(LOG_FILE_NAME, 'timestamp,latitude,longitude,accuracy,device,source\n');
+  }
+
+  props.setProperty(SCRIPT_PROP_FILE_ID, file.getId());
+  return file;
+}
+
+function sanitizeText(value) {
+  return String(value).replace(/[\r\n]+/g, ' ').trim();
+}
+
+function toNumber(value, label) {
+  const num = Number(value);
+  if (Number.isNaN(num)) {
+    throw new Error('Missing or invalid ' + label);
+  }
+  return num;
+}
+
+function toOptionalNumber(value) {
+  const num = Number(value);
+  return Number.isNaN(num) ? null : num;
+}
+
+function createJsonResponse(obj) {
+  return ContentService
+    .createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}

--- a/index.html
+++ b/index.html
@@ -128,6 +128,20 @@
       color: #856404;
       margin-left: 8px;
     }
+
+    .release-note {
+      border: 1px solid #2563eb;
+      background-color: #eef2ff;
+      padding: 12px 16px;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    .release-note strong {
+      color: #1d4ed8;
+    }
   </style>
 </head>
 
@@ -168,8 +182,13 @@
     }
   </script>
 
-  <!-- version: v6.12 | Updated: 2025-08-22 (2025-08-16) -->
-  <div class="status-bar">v6.12 | Updated: 2025-08-22 | Updated: 2025-08-16 | Auth Protected + FacePack Dashboard | 🔐 Secure Access Enabled
+  <!-- version: v6.15 | Updated: 2025-10-17 11:30 (GMT+8) -->
+  <div class="status-bar">v6.15 | Updated: 2025-10-17 11:30 (GMT+8) | Auth Protected + FacePack Dashboard | 📍 GPS Logger Deployment Fixes | 🔐 Secure Access Enabled
+  </div>
+
+  <div class="release-note">
+    <strong>v6.15 – 2025-10-17 11:30 (GMT+8):</strong> Added the Mobile GPS Logger entry to the index so the Apps Script capture page is one tap away for phone deployments.
+    Keeps the GPS fixes from v6.14 while improving discoverability directly from the main dashboard.
   </div>
 
   <button class="logout-btn" onclick="logout()">🚪 Logout</button>
@@ -207,7 +226,8 @@
       { title: "Voice Content Speaker v6.12 | Updated: 2025-08-22 | 語音內容播放器 + 資料面板", file: "voice.html", exists: true },
       { title: "FacePack.ID Dashboard | 面部識別數據面板", file: "facepack.html", exists: true },
       { title: "Add Link Manager | 連結管理器", file: "add_link.html", exists: true },
-      { title: "ChatGPT Drive Console | ChatGPT 雲端控制台", file: "ui.html", exists: true }
+      { title: "ChatGPT Drive Console | ChatGPT 雲端控制台", file: "ui.html", exists: true },
+      { title: "Mobile GPS Logger | 行動定位紀錄器", file: "gpsLogger.html", exists: true }
     ];
 
     const pageList = document.getElementById("pageList");

--- a/index.html
+++ b/index.html
@@ -142,6 +142,52 @@
     .release-note strong {
       color: #1d4ed8;
     }
+
+    .gps-card {
+      margin-top: 30px;
+      padding: 18px 20px;
+      border: 1px solid #1d4ed8;
+      background: #f8fbff;
+      border-radius: 10px;
+      box-shadow: 0 6px 16px rgba(29, 78, 216, 0.12);
+    }
+
+    .gps-card h3 {
+      margin-top: 0;
+      color: #1d4ed8;
+    }
+
+    .gps-card p {
+      font-size: 14px;
+      color: #334155;
+      line-height: 1.6;
+    }
+
+    .gps-card .gps-actions {
+      margin-top: 16px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .gps-card .gps-button {
+      padding: 10px 16px;
+      border-radius: 999px;
+      border: none;
+      background: #2563eb;
+      color: #fff;
+      font-size: 14px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      transition: background-color 0.3s ease;
+    }
+
+    .gps-card .gps-button:hover {
+      background: #1e3a8a;
+    }
   </style>
 </head>
 
@@ -182,13 +228,13 @@
     }
   </script>
 
-  <!-- version: v6.15 | Updated: 2025-10-17 11:30 (GMT+8) -->
-  <div class="status-bar">v6.15 | Updated: 2025-10-17 11:30 (GMT+8) | Auth Protected + FacePack Dashboard | 📍 GPS Logger Deployment Fixes | 🔐 Secure Access Enabled
+  <!-- version: v6.16 | Updated: 2025-10-17 15:45 (GMT+8) -->
+  <div class="status-bar">v6.16 | Updated: 2025-10-17 15:45 (GMT+8) | Auth Protected + FacePack Dashboard | 📍 GPS Logger Quick Access Card | 🔐 Secure Access Enabled
   </div>
 
   <div class="release-note">
-    <strong>v6.15 – 2025-10-17 11:30 (GMT+8):</strong> Added the Mobile GPS Logger entry to the index so the Apps Script capture page is one tap away for phone deployments.
-    Keeps the GPS fixes from v6.14 while improving discoverability directly from the main dashboard.
+    <strong>v6.16 – 2025-10-17 15:45 (GMT+8):</strong> Added a dedicated Mobile GPS Logger quick-launch card at the bottom of the index so teams can trigger captures without leaving the dashboard.
+    Retains the v6.15 entry while offering inline documentation and a one-tap launch experience.
   </div>
 
   <button class="logout-btn" onclick="logout()">🚪 Logout</button>
@@ -213,6 +259,22 @@
     <ul id="userLinksList" class="page-list">
       <!-- User added links will appear here -->
     </ul>
+  </div>
+
+  <div class="gps-card">
+    <h3>📍 Mobile GPS Logger Quick Launch | 快速啟動定位紀錄器</h3>
+    <p>
+      Access the Google Apps Script capture interface directly from here. The logger requests your phone's GPS permission and
+      writes the coordinates to <strong>Lfile</strong> in the <em>chatgpt</em> Drive folder with accuracy and device metadata for auditing.
+    </p>
+    <div class="gps-actions">
+      <a class="gps-button" href="gpsLogger.html">
+        🚀 Open GPS Logger Page
+      </a>
+      <button class="gps-button" style="background:#10b981;" onclick="window.open('https://script.google.com/', '_blank')">
+        📄 Deployment Guide
+      </button>
+    </div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- harden the Google Apps Script GPS logger with POST support, stricter validation, and cached Drive lookups so deployment succeeds reliably
- refresh the mobile capture page with entry previews and corrected markup to surface the most recent log line
- bump the project documentation and index banner to v6.15 with a GMT+8 release note covering the deployment fixes and new index shortcut
- add the Mobile GPS Logger entry to the main index list so the capture UI is directly accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f100f35374832d92751885b1ff18e2